### PR TITLE
Fixed typo from ckass to class on navlink in nav bar.

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
             <li><a class="nav-link" href="#variables">Variables</a></li>
             <li><a class="nav-link" href="#variable_scope">Variable Scope</a></li>
             <li><a class="nav-link" href="#functions">Functions</a></li>
-            <li><a ckass="nav-link" href="#closures">Closures</a></li>
+            <li><a class="nav-link" href="#closures">Closures</a></li>
             <li><a class="nav-link" href="#references">References</a></li>
         </ul>
     </nav>


### PR DESCRIPTION
Noticed this typo while I was playing with themes. Not sure if it has an impact - you might want to double-check your CSS for the navbar to verify that no styles were applied to compensate for the missing class.